### PR TITLE
Docs: update json schemas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,8 @@
         "editor.quickSuggestions": {
             "strings": true
         },
-        "editor.suggest.insertMode": "replace"
+        "editor.suggest.insertMode": "replace",
+        "files.insertFinalNewline": true
     },
     // Markdown
     "markdown.updateLinksOnFileMove.enabled": "prompt",

--- a/docs/schemas/profile/qgis_profile.json
+++ b/docs/schemas/profile/qgis_profile.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/raw/main/docs/schemas/profile/qgis_profile.json",
-    "$comment": "A QGIS profile described in a JSON file.",
+    "$comment": "A QGIS profile described in a JSON file in the QDT formalism.",
     "type": "object",
     "properties": {
         "alias": {
@@ -44,14 +44,14 @@
             }
         },
         "qgisMaximumVersion": {
-            "description": "Maximum QGIS version where the profile can be deployed.",
+            "description": "Maximum QGIS version where the profile can be deployed. It should complies with SemVer.",
             "maxLength": 14,
             "minLength": 5,
             "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$",
             "type": "string"
         },
         "qgisMinimumVersion": {
-            "description": "Minimum QGIS version where the profile can be deployed.",
+            "description": "Minimum QGIS version where the profile can be deployed. It should complies with SemVer.",
             "maxLength": 14,
             "minLength": 5,
             "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$",

--- a/docs/schemas/profile/rules.json
+++ b/docs/schemas/profile/rules.json
@@ -58,7 +58,7 @@
             "type": "string"
         }
     },
-    "definitions": {
+    "defs": {
         "conditionArray": {
             "type": "array",
             "title": "Condition Array",

--- a/docs/schemas/scenario/jobs/qdt_job_base.json
+++ b/docs/schemas/scenario/jobs/qdt_job_base.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/scenario/jobs/generic.json",
+  "$id": "https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/main/docs/schemas/scenario/jobs/qdt_job_base.json",
   "description": "Definition of a job, i.e. a logic execution which can be ran during a step.",
   "title": "Steps",
   "type": "array",

--- a/docs/schemas/scenario/jobs/qdt_job_base.json
+++ b/docs/schemas/scenario/jobs/qdt_job_base.json
@@ -125,7 +125,7 @@
             "$ref": "qgis-installation-finder.json"
           }
         }
-      },
+      }
     ],
     "required": [
       "name",

--- a/docs/schemas/scenario/qdt_scenario.json
+++ b/docs/schemas/scenario/qdt_scenario.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/raw/main/docs/schemas/scenario/schema.json",
+  "$id": "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/raw/main/docs/schemas/scenario/qdt_scenario.json",
   "$comment": "Deploy and configure QGIS and related components (plugins, shortcuts, etc.).",
   "type": "object",
   "properties": {


### PR DESCRIPTION
- [x] use new project URLS
- [ ] since we introduced rules, schema validation is not working anymore (have look upstream https://github.com/CacheControl/json-rules-engine/issues/366#issuecomment-2486081909)
- [ ] it's systematically failing when used as git hook https://results.pre-commit.ci/run/github/513467425/1732618307.uEV3saFBQmCiG-kNJ9aRNA