### PR TITLE
fix(test): make sure dl_url is a string

### DIFF
--- a/tests/test_cli_upgrade.py
+++ b/tests/test_cli_upgrade.py
@@ -80,7 +80,16 @@ class TestUpgradeUtils(unittest.TestCase):
             for os in SUPPORTED_OPERATING_SYSTEMS_CODENAMES
         ]
         self.assertTrue(len(dl_hyperlinks), 3)
-        self.assertTrue(all([dl_url.startswith("https") for dl_url in dl_hyperlinks]))
+
+        self.assertTrue(
+            all(
+                [
+                    dl_url.startswith("https")
+                    for dl_url in dl_hyperlinks
+                    if isinstance(dl_url, str)
+                ]
+            )
+        )
 
 
 # #############################################################################


### PR DESCRIPTION
Example of failed job: https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/actions/runs/12087850915/job/33710161685