### PR TITLE
update(ci): use macos-15 since macos-12 is deprecated

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -72,7 +72,7 @@ jobs:
 
   build-macos:
     name: "🍏 Mac OS"
-    runs-on: macos-12
+    runs-on: macos-15
 
     steps:
       - name: Get source code


### PR DESCRIPTION
See: https://github.com/actions/runner-images/issues/10721