### PR TITLE
fix(docs): simplify JSON schema of job qgis-finder

### DIFF
--- a/docs/schemas/scenario/jobs/qgis-installation-finder.json
+++ b/docs/schemas/scenario/jobs/qgis-installation-finder.json
@@ -1,35 +1,34 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/raw/main/docs/schemas/scenario/jobs/qgis-installation-finder.json",
-  "description": "Job in charge of findind installed QGIS version on computer.",
+  "description": "Job in charge of finding installed QGIS version on computer.",
   "title": "QGIS installation finder",
   "type": "object",
-  "items": {
-    "properties": {
-      "version_priority": {
-        "default": "",
-        "description": "Define QGIS version priority for search.",
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "if_not_found": {
-        "default": "warning",
-        "description": "Behavior if no QGIS installation found.",
-        "enum": [
-          "warning",
-          "error"
-        ],
+  "properties": {
+    "version_priority": {
+      "default": "",
+      "description": "Define QGIS version priority for search.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
         "type": "string"
-      },
-      "search_paths": {
-        "default": "",
-        "description": "Define search paths for QGIS installation.",
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
+      }
+    },
+    "if_not_found": {
+      "default": "warning",
+      "description": "Behavior if no QGIS installation found.",
+      "enum": [
+        "warning",
+        "error"
+      ],
+      "type": "string"
+    },
+    "search_paths": {
+      "default": "",
+      "description": "Define search paths for QGIS installation.",
+      "type": "array",
+      "items": {
+        "type": "string"
       }
     }
   }


### PR DESCRIPTION
Following up of #600 

Before:

> after PR #600


![](https://pad.oslandia.net/uploads/4e445daa-2e84-40f1-9573-ce24882dd97d.png)

- the schema does not matches structure, so validation is not really working
- it's "visible" with missing tooltip when over on keywords


After this PR:

![](https://pad.oslandia.net/uploads/f2e76dd1-69f7-4a54-b5c2-956589df80eb.png)

See visible tooltips when mouse hover
