### PR TITLE
Add new job "default-profile-setter"

### DIFF
--- a/docs/jobs/default_profile_setter.md
+++ b/docs/jobs/default_profile_setter.md
@@ -1,0 +1,33 @@
+# Shortcuts manager
+
+Use this job to set the default profile in profiles.ini file.
+
+----
+
+## Use it
+
+Sample job configuration in your scenario file:
+
+```yaml
+- name: Set default profile to conf_qgis_fr
+    uses: default-profile-setter
+    with:
+      profile: conf_qgis_fr
+```
+
+----
+
+## Options
+
+### profile
+
+Name of the profile to set as default profile.
+
+----
+
+## Schema
+
+```{eval-rst}
+.. literalinclude:: ../schemas/scenario/jobs/default-profile-setter.json
+  :language: json
+```

--- a/docs/jobs/index.md
+++ b/docs/jobs/index.md
@@ -6,6 +6,7 @@ caption: Jobs
 maxdepth: 1
 glob:
 ---
+default_profile_setter.md
 environment_variables.md
 qgis_installation_finder.md
 plugins_downloader.md

--- a/docs/schemas/scenario/jobs/default-profile-setter.json
+++ b/docs/schemas/scenario/jobs/default-profile-setter.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/raw/main/docs/schemas/scenario/jobs/shortcuts-manager.json",
+    "description": "Set the default profile ine profile.ini",
+    "title": "Default profile paths.",
+    "type": "object",
+    "profile": {
+        "action": {
+            "description": "Name of the profile to set as default profile.",
+            "type": "string"
+        }
+    }
+}

--- a/docs/schemas/scenario/jobs/qdt_job_base.json
+++ b/docs/schemas/scenario/jobs/qdt_job_base.json
@@ -23,6 +23,7 @@
         "minLength": 1,
         "maxLength": 255,
         "enum": [
+          "default-profile-setter",
           "manage-env-vars",
           "qgis-installation-finder",
           "qplugins-downloader",
@@ -46,6 +47,16 @@
       }
     },
     "oneOf": [
+      {
+        "properties": {
+          "uses": {
+            "const": "default-profile-setter"
+          },
+          "with": {
+            "$ref": "default-profile-setter.json"
+          }
+        }
+      },
       {
         "properties": {
           "uses": {

--- a/docs/schemas/scenario/jobs/qplugins-synchronizer.json
+++ b/docs/schemas/scenario/jobs/qplugins-synchronizer.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/raw/main/docs/schemas/scenario/jobs/qplugins-synchronizer.json",
-    "description": "synchronize plugins between those stored locally (typically downloaded by the Plugins Downloader job) and the installed plugins.",
+    "description": "Synchronize plugins between those stored locally (typically downloaded by the Plugins Downloader job) and the installed plugins.",
     "title": "QPlugins Synchronizer.",
     "type": "object",
     "properties": {

--- a/docs/schemas/scenario/jobs/shortcuts-manager.json
+++ b/docs/schemas/scenario/jobs/shortcuts-manager.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/raw/main/docs/schemas/scenario/jobs/shortcuts-manager.json",
-    "description": "create shortcuts in desktop and/or start menu allowing the end-user opening QGIS with a profile.",
+    "description": "Create shortcuts in desktop and/or start menu allowing the end-user opening QGIS with a profile.",
     "title": "Shortcuts Manager.",
     "type": "object",
     "properties": {

--- a/qgis_deployment_toolbelt/jobs/generic_job.py
+++ b/qgis_deployment_toolbelt/jobs/generic_job.py
@@ -103,7 +103,7 @@ class GenericJob:
             `%APPDATA%/QGIS/QGIS3/profiles/geotribu`).
 
         Returns:
-            tuple[QdtProfile] | None: tuple of profiles objects or Non if no profile is
+            tuple[QdtProfile] | None: tuple of profiles objects or None if no profile is
                 installed in QGIS3/profiles
         """
         return self.filter_profiles_folder(start_parent_folder=self.qgis_profiles_path)
@@ -151,6 +151,36 @@ class GenericJob:
             )
 
         return tuple(profiles_matched)
+
+    def get_matching_profile_from_name(
+        self, li_profiles: list[QdtProfile], profile_name: str
+    ) -> QdtProfile:
+        """Get a profile from list of profiles using a profile's name to match.
+
+        Args:
+            li_profiles (list[QdtProfile]): list of profile to look into
+            profile_name (str): profile name
+
+        Returns:
+            QdtProfile: matching profile object
+        """
+        # load profile
+        matching_qdt_profile = [
+            pr for pr in li_profiles if profile_name in (pr.name, pr.folder.name)
+        ]
+        if not len(matching_qdt_profile):
+            logger.error(
+                "Unable to get a matching profile among downloaded ones with "
+                f"the name: {profile_name}"
+            )
+            return None
+
+        qdt_profile = matching_qdt_profile[0]
+        logger.info(
+            f"Downloaded profile matched: {qdt_profile.name} from "
+            f"{qdt_profile.folder}"
+        )
+        return qdt_profile
 
     @lru_cache(maxsize=1024)
     def filter_profiles_on_rules(

--- a/qgis_deployment_toolbelt/jobs/job_default_profile_setter.py
+++ b/qgis_deployment_toolbelt/jobs/job_default_profile_setter.py
@@ -1,0 +1,110 @@
+#! python3  # noqa: E265
+
+"""
+Set the default profile in profiles.ini file.
+
+Author: Nicolas Godet (https://github.com/nicogodet)
+"""
+
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import logging
+
+# package
+from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+from qgis_deployment_toolbelt.utils.ini_parser_with_path import CustomConfigParser
+
+# #############################################################################
+# ########## Globals ###############
+# ##################################
+
+# logs
+logger = logging.getLogger(__name__)
+
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class JobDefaultProfileSetter(GenericJob):
+    """
+    Job to set the default profile in profile.ini file.
+    """
+
+    ID: str = "default-profile-setter"
+    OPTIONS_SCHEMA: dict = {
+        "profile": {
+            "type": str,
+            "required": True,
+            "default": None,
+            "possible_values": None,
+            "condition": None,
+        },
+    }
+
+    def __init__(self, options: dict) -> None:
+        """Instantiate the class.
+
+        Args:
+            options (List[dict]): list of dictionary with environment variables to set
+            or remove.
+        """
+        super().__init__()
+        self.options: dict = self.validate_options(options)
+
+    def run(self) -> None:
+        """Execute job logic."""
+        # check of there are some profiles folders within the installed folder
+        installed_profiles = self.list_installed_profiles()
+        if installed_profiles is None:
+            logger.error("No QGIS profile found in the installed folder.")
+            return
+
+        # check if the provided profile name exists in the installed profiles
+        qdt_profile = self.get_matching_profile_from_name(
+            li_profiles=installed_profiles,
+            profile_name=self.options.get("profile"),
+        )
+        if not qdt_profile:
+            logger.error("No QGIS profile matching the provided profile name.")
+            return
+
+        ini_profiles_path = self.qgis_profiles_path / "profiles.ini"
+
+        # check if the profiles.ini file exists and create it with default profile set
+        # if not
+        if not ini_profiles_path.exists():
+            logger.warning(
+                "Configuration file profiles.ini doesn't exist. "
+                "It will be created but maybe it was not the expected behavior."
+            )
+            ini_profiles_path.touch(exist_ok=True)
+            ini_profiles_path.write_text(
+                data=f"[core]\ndefaultProfile={self.options.get('profile')}\nselectionPolicy=1",
+                encoding="UTF8",
+            )
+            logger.info(f"Default profile set to {self.options.get('profile')}")
+            logger.debug(f"Job {self.ID} ran successfully.")
+            return
+
+        ini_profiles = CustomConfigParser()
+        ini_profiles.optionxform = str
+        ini_profiles.read(self.qgis_profiles_path / "profiles.ini", encoding="UTF8")
+
+        # set the default profile
+        if not ini_profiles.has_section("core"):
+            ini_profiles.add_section("core")
+
+        ini_profiles.set("core", "defaultProfile", self.options.get("profile"))
+        ini_profiles.set("core", "selectionPolicy", "1")
+
+        with ini_profiles_path.open("w", encoding="UTF8") as wf:
+            ini_profiles.write(wf, space_around_delimiters=False)
+            logger.info(f"Default profile set to {self.options.get('profile')}")
+
+        logger.debug(f"Job {self.ID} ran successfully.")

--- a/qgis_deployment_toolbelt/jobs/job_shortcuts.py
+++ b/qgis_deployment_toolbelt/jobs/job_shortcuts.py
@@ -156,36 +156,6 @@ class JobShortcutsManager(GenericJob):
             raise NotImplementedError
 
     # -- INTERNAL LOGIC ------------------------------------------------------
-    def get_matching_profile_from_name(
-        self, li_profiles: list[QdtProfile], profile_name: str
-    ) -> QdtProfile:
-        """Get a profile from list of profiles using a profile's name to match.
-
-        Args:
-            li_profiles (list[QdtProfile]): list of profile to look into
-            profile_name (str): profile name
-
-        Returns:
-            QdtProfile: matching profile object
-        """
-        # load profile
-        matching_qdt_profile = [
-            pr for pr in li_profiles if profile_name in (pr.name, pr.folder.name)
-        ]
-        if not len(matching_qdt_profile):
-            logger.error(
-                "Unable to get a matching profile among downloaded ones with "
-                f"the name: {profile_name}"
-            )
-            return None
-
-        qdt_profile = matching_qdt_profile[0]
-        logger.info(
-            f"Downloaded profile matched: {qdt_profile.name} from "
-            f"{qdt_profile.folder}"
-        )
-        return qdt_profile
-
     def get_icon_path(self, profile: QdtProfile, icon_filename: str) -> Path | None:
         """Get icon path to use with the shortcut. Looking for:
 

--- a/qgis_deployment_toolbelt/jobs/orchestrator.py
+++ b/qgis_deployment_toolbelt/jobs/orchestrator.py
@@ -17,6 +17,9 @@ from os import environ
 
 # project
 from qgis_deployment_toolbelt.jobs.generic_job import GenericJob
+from qgis_deployment_toolbelt.jobs.job_default_profile_setter import (
+    JobDefaultProfileSetter,
+)
 from qgis_deployment_toolbelt.jobs.job_environment_variables import (
     JobEnvironmentVariables,
 )
@@ -50,6 +53,7 @@ class JobsOrchestrator:
     """Orchestrate jobs."""
 
     JOBS: tuple = (
+        JobDefaultProfileSetter,
         JobEnvironmentVariables,
         JobPluginsDownloader,
         JobPluginsSynchronizer,

--- a/tests/fixtures/scenarios/good_scenario_plugins_downloader_force.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_plugins_downloader_force.qdt.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/refs/heads/main/docs/schemas/scenario/qdt_scenario.json
+# yaml-language-server: $schema=../../../docs/schemas/scenario/qdt_scenario.json
 
 # This is a sample of a YAML file for the QGIS Deployment Toolbelt scenario.
 # For now, it's more a roadmap than a real description of what it's implemented.

--- a/tests/fixtures/scenarios/good_scenario_profiles_http.yml
+++ b/tests/fixtures/scenarios/good_scenario_profiles_http.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../docs/schemas/scenario/qdt_scenario.json
+
 # This is a sample of a YAML file for the QGIS Deployment Toolbelt scenario.
 # For now, it's more a roadmap than a real description of what it's implemented.
 

--- a/tests/fixtures/scenarios/good_scenario_profiles_only_different.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_profiles_only_different.qdt.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../docs/schemas/scenario/qdt_scenario.json
+
 # This is a sample of a YAML file for the QGIS Deployment Toolbelt scenario.
 # For now, it's more a roadmap than a real description of what it's implemented.
 

--- a/tests/fixtures/scenarios/good_scenario_profiles_only_missing.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_profiles_only_missing.qdt.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../docs/schemas/scenario/qdt_scenario.json
+
 # This is a sample of a YAML file for the QGIS Deployment Toolbelt scenario.
 # For now, it's more a roadmap than a real description of what it's implemented.
 

--- a/tests/fixtures/scenarios/good_scenario_sample.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_sample.qdt.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/refs/heads/main/docs/schemas/scenario/qdt_scenario.json
+# yaml-language-server: $schema=../../../docs/schemas/scenario/qdt_scenario.json
 
 # This is a sample of a YAML file for the QGIS Deployment Toolbelt scenario.
 # For now, it's more a roadmap than a real description of what it's implemented.
@@ -72,3 +72,8 @@ steps:
     with:
       action: create_or_restore
       strict: false
+
+  - name: Set default profile
+    uses: default-profile-setter
+    with:
+      profile: qdt_demo

--- a/tests/fixtures/scenarios/good_scenario_splash_screen_remove.qdt.yml
+++ b/tests/fixtures/scenarios/good_scenario_splash_screen_remove.qdt.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../../../docs/schemas/scenario/qdt_scenario.json
+
 # This is a sample of a YAML file for the QGIS Deployment Toolbelt scenario.
 # For now, it's more a roadmap than a real description of what it's implemented.
 

--- a/tests/fixtures/scenarios/scenario_sample_as_admin.qdt.yml
+++ b/tests/fixtures/scenarios/scenario_sample_as_admin.qdt.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/qgis-deployment/qgis-deployment-toolbelt-cli/refs/heads/main/docs/schemas/scenario/qdt_scenario.json
+# yaml-language-server: $schema=../../../docs/schemas/scenario/qdt_scenario.json
 
 # This is a sample of a YAML file for the QGIS Deployment Toolbelt scenario.
 # For now, it's more a roadmap than a real description of what it's implemented.

--- a/tests/test_job_default_profile_setter.py
+++ b/tests/test_job_default_profile_setter.py
@@ -1,0 +1,85 @@
+#! python3  # noqa E265
+
+"""Usage from the repo root folder:
+
+.. code-block:: python
+
+    # for whole test
+    python -m unittest tests.test_job_default_profile_setter
+    # for specific
+    python -m unittest tests.test_job_default_profile_setter.TestJobDefaultProfileSetter.test_job_default_profile_setter_run
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import tempfile
+import unittest
+from pathlib import Path
+
+# package
+from qgis_deployment_toolbelt.jobs.job_default_profile_setter import (
+    JobDefaultProfileSetter,
+)
+
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+class TestJobDefaultProfileSetter(unittest.TestCase):
+    """Test default profile setter job."""
+
+    # -- Standard methods --------------------------------------------------------
+    @classmethod
+    def setUpClass(cls):
+        """Executed when module is loaded before any test."""
+        cls.default_profile_setter_job = JobDefaultProfileSetter(
+            options={"profile": "qdt_test_profile_minimal"}
+        )
+        cls.default_profile_setter_job.qgis_profiles_path = (
+            Path(tempfile.mkdtemp()) / "profiles"
+        )
+        cls.default_profile_setter_job.qgis_profiles_path.mkdir(
+            parents=True, exist_ok=True
+        )
+        cls.profiles_ini = (
+            cls.default_profile_setter_job.qgis_profiles_path / "profiles.ini"
+        )
+
+        # simulate a QGIS profiles folder structure in the temp folder
+        fixtures_profiles_folder = Path("tests/fixtures/profiles")
+        for p in fixtures_profiles_folder.glob("good_profile_*.json"):
+            dest_file = cls.default_profile_setter_job.qgis_profiles_path.joinpath(
+                f"test_{p.stem}/profile.json"
+            )
+            dest_file.parent.mkdir(parents=True, exist_ok=True)
+            dest_file.write_text(p.read_text(encoding="UTF-8"), encoding="UTF-8")
+
+    # -- TESTS --------------------------------------------------------------------
+    def test_job_default_profile_setter_run(self):
+        """Run the job."""
+        self.assertFalse(self.profiles_ini.exists())
+        self.default_profile_setter_job.run()
+        self.assertTrue(self.profiles_ini.exists())
+
+        content = self.profiles_ini.read_text()
+        expected_content = (
+            "[core]\ndefaultProfile=qdt_test_profile_minimal\nselectionPolicy=1"
+        )
+        self.assertEqual(content, expected_content)
+
+    def test_job_default_profile_setter_run_with_existing_profiles_ini(self):
+        """Run the job with existing profiles.ini."""
+        self.profiles_ini.write_text(
+            "[core]\ndefaultProfile=existing_profile\nselectionPolicy=1"
+        )
+        self.default_profile_setter_job.run()
+        self.assertTrue(self.profiles_ini.exists())
+
+        content = self.profiles_ini.read_text()
+        expected_content = (
+            "[core]\ndefaultProfile=qdt_test_profile_minimal\nselectionPolicy=1\n\n"
+        )
+        self.assertEqual(content, expected_content)


### PR DESCRIPTION
Fixes https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/issues/611

# Why ?

Some users might double-click on .qgs/.qgz project file. In this case, QGIS will be openned without `--profile` argument and `lastProfile` or `defaultProfile` in `profiles.ini` will be used which is unwanted, the deployed profile should be used