### PR TITLE
update(ci): set GH permission scope to improve security

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -28,6 +28,10 @@ env:
   PYTHON_VERSION: "3.12"
   PYINSTALLER_LOG_LEVEL: "DEBUG"
 
+# Sets permissions of the GITHUB_TOKEN
+permissions:
+  contents: read
+
 # Jobs definition
 jobs:
   build-python-wheel:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,14 @@ name: "🐍 Linter"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
       - "**.py"
 
   pull_request:
-    branches: [main]
+    branches:
+      - main
     paths:
       - "**.py"
 
@@ -15,9 +17,13 @@ env:
   PROJECT_FOLDER: "qgis_deployment_toolbelt"
   PYTHON_VERSION: "3.10"
 
+# Sets permissions of the GITHUB_TOKEN
+permissions:
+  contents: read
+
 jobs:
   lint-ubuntu:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Get source code

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,11 @@ env:
   PROJECT_FOLDER: "qgis_deployment_toolbelt"
   PYTHON_VERSION: "3.11"
 
-  # Jobs definition
+# Sets permissions of the GITHUB_TOKEN
+permissions:
+  contents: read
+
+# Jobs definition
 jobs:
   check-bandit:
     name: "🦹‍♂️ Bandit"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,10 @@ on:
 env:
   PROJECT_FOLDER: "qgis_deployment_toolbelt"
 
+# Sets permissions of the GITHUB_TOKEN
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     strategy:


### PR DESCRIPTION
Closing https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/security/code-scanning?query=is%3Aopen+branch%3Amain+rule%3Aactions%2Fmissing-workflow-permissions