### PR TITLE
Store decoded branch name instead of bytes

### DIFF
--- a/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
+++ b/qgis_deployment_toolbelt/profiles/profiles_handler_base.py
@@ -374,7 +374,7 @@ class RemoteProfilesHandlerBase:
         if isinstance(local_git_repository, Repo):
             self.DESTINATION_BRANCH_TO_USE = porcelain.active_branch(
                 local_git_repository
-            )
+            ).decode()
 
         return local_git_repository
 


### PR DESCRIPTION

`DESTINATION_BRANCH_TO_USE` 

- is "declared" as a string

https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/38859d135c7561f8b3bc2d6525405f64f56d4e1c/qgis_deployment_toolbelt/profiles/profiles_handler_base.py#L62

- is always populated with a string in : 
   - __init__
   - https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/38859d135c7561f8b3bc2d6525405f64f56d4e1c/qgis_deployment_toolbelt/profiles/local_git_handler.py#L98-L104  
     ```python
     def get_active_branch_from_local_repository(self, local_git_repository_path: Path | None = None) -> str:
     ```
   - ...

Without this change, the type of this variable becomes mixed `str | bytes`

But indeed, it needs to be converted to bytes at some point ([here](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/38859d135c7561f8b3bc2d6525405f64f56d4e1c/qgis_deployment_toolbelt/profiles/profiles_handler_base.py#L492-L500)) but it's cleaner to let the function handles the conversion instead of store the branch name as bytes

In my case, I relied on str type when testing https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/pull/661 and I end up comparing `"main"` with `b"main"` equals False