### PR TITLE
feat: implement dynamic versioning with setuptools_scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ bandit_report.csv
 tests/fixtures/http-test-local/qdt-files.json
 docs/reference/rules_context.json
 safety_report.html
+qgis_deployment_toolbelt/_version.py

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -5,7 +5,6 @@
     1. In `Choose a tag`, enter the new tag (obviously complying with [SemVer](https://semver.org/))
     1. Click on `Generate release notes`
     1. Copy/paste the generated text from `## What's changed` until the line before `**Full changelog**:...` in the CHANGELOG.md replacing `What's changed` with the tag and the publication date
-1. Change the version number in `__about__.py`
 1. Commit changes with a message like `release: bump version to X.x.x` to the main branch
 1. Apply a git tag with the relevant version: `git tag -a 0.3.0 {git commit hash} -m "New awesome feature"`
 1. Push commit and tag to main branch: `git push --tags`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,9 +161,11 @@ norecursedirs = ".* build dev development dist docs CVS fixtures _darcs {arch} *
 python_files = "test_*.py"
 testpaths = ["tests"]
 
+[tool.setuptools_scm]
+write_to = "qgis_deployment_toolbelt/_version.py"
 
 [tool.setuptools.dynamic]
-version = { attr = "qgis_deployment_toolbelt.__about__.__version__" }
+version = { attr = "qgis_deployment_toolbelt._version.version" }
 
 [tool.setuptools.package-data]
 qgis_deployment_toolbelt = ["shortcuts/*.template"]

--- a/qgis_deployment_toolbelt/__about__.py
+++ b/qgis_deployment_toolbelt/__about__.py
@@ -40,10 +40,14 @@ __uri_repository__ = "https://github.com/qgis-deployment/qgis-deployment-toolbel
 __uri_tracker__ = f"{__uri_repository__}issues/"
 __uri__ = __uri_repository__
 
-__version__ = "0.38.0"
-__version_info__ = tuple(
-    [
-        int(num) if num.isdigit() else num
-        for num in __version__.replace("-", ".", 1).split(".")
-    ]
-)
+try:
+    from ._version import version as __version__
+except ImportError:
+    try:
+        # Fallback for development versions or when package is not installed
+        from importlib.metadata import version
+
+        __version__ = version("qgis-deployment-toolbelt")
+    except ImportError:
+        # Final fallback
+        __version__ = "0.0.0+unknown"

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -46,7 +46,6 @@ class TestAbout(unittest.TestCase):
         self.assertIsInstance(__about__.__uri_tracker__, str)
         self.assertIsInstance(__about__.__uri__, str)
         self.assertIsInstance(__about__.__version__, str)
-        self.assertIsInstance(__about__.__version_info__, tuple)
 
         # misc
         self.assertLessEqual(len(__about__.__title_clean__), len(__about__.__title__))


### PR DESCRIPTION
- Replace hardcoded __version__ with setuptools_scm integration
- Configure setuptools_scm to write version to _version.py
- Add fallback mechanisms for development environments
- Update .gitignore to exclude generated _version.py

This change enables automatic version management from git tags,
eliminating the need to manually update version strings.