### PR TITLE
Fix: RemoteProfilesHandlerBase.list_remote_branches for newer versions of dulwich.porcelain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
     "distro==1.9.* ; sys_platform == 'linux'",
-    "dulwich>=0.22.5,<0.24.2",
+    "dulwich>=0.24.1,<0.24.2",
     "giturlparse>=0.12,<0.13",
     "imagesize>=1.4,<1.5",
     "packaging>=22,<26",

--- a/tests/test_git_handler_remote.py
+++ b/tests/test_git_handler_remote.py
@@ -121,3 +121,14 @@ class TestGitHandlerRemote(unittest.TestCase):
 
             # check pull is working
             git_handler.clone_or_pull(to_local_destination_path=local_dest)
+
+    def test_list_remote_branches(self):
+        """Test listing remote branches."""
+        self.good_git_url = "https://gitlab.com/Oslandia/qgis/profils_qgis_fr.git"
+        git_handler = RemoteGitHandler(source_repository_url=self.good_git_url)
+
+        branches = git_handler.list_remote_branches()
+        self.assertIsInstance(branches, tuple)
+        self.assertGreaterEqual(len(branches), 1)
+        self.assertIsInstance(branches[0], str)
+        self.assertIn("refs/heads/main", branches)


### PR DESCRIPTION
Between 0.38.0 and 0.38.2, we bump dulwich from 0.22 to 0.24 and a lot happened between these 2 versions.

This fixes this issue: 

```powershell
PS > ./qdt.exe -s https://gitlab.com/isl-ingenierie/qgis/isl_qgis_profiles/-/raw/main/scenarios/scenario_isl_qdt.yml?ref_type=heads
ERROR:qgis_deployment_toolbelt.profiles.remote_git_handler:Specified branch 'main' has not been found in source repository (https://gitlab.com/isl-ingenierie/qgis/isl_qgis_profiles.git). Fallback to identified active branch: None.
```

Because porcelain.ls_remote now return LsRemoteResult and not a dict anymore.
dict logic has been kept for back compatibility

A test has been added too to prevent futur silent regression