### PR TITLE
Docs and upgrade: distinguish current version from last release

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
       - name: Get source code
         uses: actions/checkout@v4
+        with: 
+            fetch-depth: 0
+            fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -81,6 +84,9 @@ jobs:
     steps:
       - name: Get source code
         uses: actions/checkout@v4
+        with: 
+            fetch-depth: 0
+            fetch-tags: true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -115,6 +121,9 @@ jobs:
     steps:
       - name: Get source code
         uses: actions/checkout@v4
+        with: 
+            fetch-depth: 0
+            fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -148,6 +157,9 @@ jobs:
     steps:
       - name: Get source code
         uses: actions/checkout@v4
+        with: 
+            fetch-depth: 0
+            fetch-tags: true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -321,6 +333,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with: 
+            fetch-depth: 0
+            fetch-tags: true
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Get source code
         uses: actions/checkout@v4
         with:
+            fetch-depth: 0
             fetch-tags: true
 
       - name: Set up Python

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Get source code
         uses: actions/checkout@v4
+        with:
+            fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,9 @@ author = __about__.__author__
 copyright = __about__.__copyright__
 description = __about__.__summary__
 project = __about__.__title__
-version = release = __about__.__version__
+version = __about__.__version__
+release = __about__.__version_clean__
+
 
 # -- General configuration ---------------------------------------------------
 
@@ -174,6 +176,7 @@ myst_substitutions = {
     "license": __about__.__license__,
     "repo_url": __about__.__uri__,
     "title": project,
+    "release": release,
     "version": version,
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,6 @@ author = __about__.__author__
 copyright = __about__.__copyright__
 description = __about__.__summary__
 project = __about__.__title__
-version = __about__.__version__
 version: str = get_version(__about__.__package_name__)
 release: str = ".".join(version.split(".")[:3])
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@ Configuration for project documentation using Sphinx.
 # standard
 import logging
 from datetime import datetime
+from importlib.metadata import version as get_version
 from pathlib import Path
 
 # project
@@ -28,7 +29,8 @@ copyright = __about__.__copyright__
 description = __about__.__summary__
 project = __about__.__title__
 version = __about__.__version__
-release = __about__.__version_clean__
+version: str = get_version(__about__.__package_name__)
+release: str = ".".join(version.split(".")[:3])
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,16 +7,10 @@ Configuration for project documentation using Sphinx.
 # standard
 import logging
 from datetime import datetime
-from importlib.metadata import version as get_version
 from pathlib import Path
 
 # project
 from qgis_deployment_toolbelt import __about__
-from qgis_deployment_toolbelt.commands.upgrade import (
-    get_download_url_for_os,
-    get_latest_release,
-    replace_domain,
-)
 from qgis_deployment_toolbelt.profiles.rules_context import QdtRulesContext
 
 
@@ -28,8 +22,8 @@ author = __about__.__author__
 copyright = __about__.__copyright__
 description = __about__.__summary__
 project = __about__.__title__
-version: str = get_version(__about__.__package_name__)
-release: str = ".".join(version.split(".")[:3])
+version: str = __about__.__version__
+release: str = __about__.release or version
 
 
 # -- General configuration ---------------------------------------------------
@@ -199,9 +193,8 @@ ogp_custom_meta_tags = [
 # sitemap
 sitemap_url_scheme = "{link}"
 
+
 # -- Functions ------------------------------------------------------------------
-
-
 def generate_rules_context(_):
     """Generate context object as JSON that it passed to rules engine to check profiles
     conditions."""
@@ -216,26 +209,9 @@ def generate_rules_context(_):
 def populate_download_page(_):
     """Generate download section included into installation page."""
     logger.warning("=== START POPULATING DOWNLOAD SECTION ===")
-    try:
-        latest_release = get_latest_release(
-            replace_domain(
-                url=__about__.__uri_repository__, new_domain="api.github.com/repos"
-            )
-        )
-
-        dl_link_linux, dl_link_macos, dl_link_windows = (
-            get_download_url_for_os(latest_release.get("assets"), override_opersys=os)[
-                0
-            ]
-            for os in ["linux", "darwin", "win32"]
-        )
-    except Exception as err:
-        logger.error(
-            f"Error occured during GitHub release calls. Fallback to current version. Trace: {err}"
-        )
-        dl_link_linux = f"{__about__.__uri_repository__}releases/download/{version}/Ubuntu_QGISDeploymentToolbelt_{version}"
-        dl_link_macos = f"{__about__.__uri_repository__}releases/download/{version}/MacOS_QGISDeploymentToolbelt_{version}"
-        dl_link_windows = f"{__about__.__uri_repository__}releases/download/{version}/Windows_QGISDeploymentToolbelt_{version}.exe"
+    dl_link_linux = f"{__about__.__uri_repository__}releases/download/{release}/Ubuntu_QGISDeploymentToolbelt_{release.replace('.', '-')}"
+    dl_link_macos = f"{__about__.__uri_repository__}releases/download/{release}/MacOS_QGISDeploymentToolbelt_{release.replace('.', '-')}"
+    dl_link_windows = f"{__about__.__uri_repository__}releases/download/{release}/Windows_QGISDeploymentToolbelt_{release.replace('.', '-')}.exe"
 
     out_download_section = (
         "::::{grid} 3\n:gutter: 2\n\n"

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,10 @@
 
 > **Description:** {{ description }}  
 > **Author and contributors:** {{ author }}  
-> **Version:** {{ version }}  
 > **Source code:** {{ repo_url }}  
 > **License:** {{ license }}  
+> **Last released version:** {{ release }}  
+> **Current version:** {{ version }}  
 > **Last documentation build:** {{ date_update }}
 
 [![PyPi version badge](https://badgen.net/pypi/v/qgis-deployment-toolbelt)](https://pypi.org/project/qgis-deployment-toolbelt/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,7 +131,7 @@ pipx run qgis-deployment-toolbelt -s https://github.com/qgis-deployment/qgis-dep
 
 1. Download latest version that matches your environment from [releases](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/releases/latest)
 1. Open a terminal in the same folder
-1. Rename 'Windows_QGISDeploymentToolbelt_{{ version | replace(".","-")  }}' as `qdt.exe`:
+1. Rename 'Windows_QGISDeploymentToolbelt_{{ release | replace(".","-")  }}' as `qdt.exe`:
 
     ```powershell
     mv *_QGISDeploymentToolbelt_* qdt.exe
@@ -147,7 +147,7 @@ pipx run qgis-deployment-toolbelt -s https://github.com/qgis-deployment/qgis-dep
 
 1. Download latest version that matches your environment from [releases](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/releases/latest)
 1. Open a terminal in the same folder
-1. Rename 'Ubuntu_QGISDeploymentToolbelt_{{ version | replace(".","-")  }}' it as `qdt.bin`:
+1. Rename 'Ubuntu_QGISDeploymentToolbelt_{{ release | replace(".","-")  }}' it as `qdt.bin`:
 
     ```sh
     mv *_QGISDeploymentToolbelt_* qdt.bin

--- a/qgis_deployment_toolbelt/__about__.py
+++ b/qgis_deployment_toolbelt/__about__.py
@@ -76,7 +76,6 @@ __version_info__ = tuple(
         for num in __version__.replace("-", ".", 1).split(".")
     ]
 )
-print(release)
 
 __all__ = [
     "__author__",

--- a/qgis_deployment_toolbelt/__about__.py
+++ b/qgis_deployment_toolbelt/__about__.py
@@ -1,13 +1,21 @@
 #! python3  # noqa: E265
 
-"""
-Metadata bout the package to easily retrieve informations about it.
-See: https://packaging.python.org/guides/single-sourcing-package-version/
+"""Package's metadata to easily retrieve informations about it.
+See: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
 """
 
+# standard lib
+import logging
 from datetime import date
 from importlib import metadata
+from os import getenv
+from pathlib import Path
+from shutil import which
+from subprocess import check_output
+from venv import logger
 
+
+logger = logging.getLogger(__name__)
 
 # import metadata from installed package, if possible
 _pkg_metadata = metadata.metadata("qgis-deployment-toolbelt") or {}
@@ -16,6 +24,29 @@ try:
     from ._version import version as __version__
 except ImportError:
     __version__ = _pkg_metadata.get("Version", "0.0.0-dev0")
+
+
+# get latest git tag if possible, if not fallback to __version__
+release: str | None = None
+try:
+    github_ref = getenv("GITHUB_REF", "")
+    if github_ref.startswith("refs/tags/"):
+        release = github_ref[len("refs/tags/") :]
+        logger.debug("Git tag found from GITHUB_REF:", release)
+    elif git_path := which("git"):
+        release = (
+            check_output(
+                [git_path, "describe", "--tags", "--abbrev=0"],
+                cwd=Path(__file__).parent.resolve(),
+            )
+            .decode()
+            .strip()
+        )
+        logger.debug("Git tag found from git:", release)
+except Exception:
+    logger.debug("No git tag found, fallback to __version__")
+    release = __version__  # fallback
+
 
 # store metadata into module attributes
 __author__: str = _pkg_metadata.get(
@@ -45,7 +76,7 @@ __version_info__ = tuple(
         for num in __version__.replace("-", ".", 1).split(".")
     ]
 )
-
+print(release)
 
 __all__ = [
     "__author__",

--- a/qgis_deployment_toolbelt/__about__.py
+++ b/qgis_deployment_toolbelt/__about__.py
@@ -38,6 +38,7 @@ __title_clean__ = "".join(e for e in __title__ if e.isalnum())
 __uri_homepage__ = "https://qgis-deployment.github.io/qgis-deployment-toolbelt-cli/"
 __uri_repository__ = "https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/"
 __uri__ = __uri_repository__
+__version_clean__: str = __version__.split(".dev")[0].split("+")[0]
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num

--- a/qgis_deployment_toolbelt/cli.py
+++ b/qgis_deployment_toolbelt/cli.py
@@ -24,6 +24,7 @@ from qgis_deployment_toolbelt.__about__ import (
     __title_clean__,
     __uri_homepage__,
     __version__,
+    __version_clean__,
 )
 from qgis_deployment_toolbelt.commands.cmd_rules_context import (
     parser_rules_context_export,
@@ -202,7 +203,8 @@ def main(in_args: list[str] | None = None):
     # log configuration
     if args.opt_logfile_disabled:
         configure_logger(
-            verbosity=args.verbosity, logfile=f"{__title_clean__}_{__version__}.log"
+            verbosity=args.verbosity,
+            logfile=f"{__title_clean__}_{__version_clean__}.log",
         )
     else:
         configure_logger(verbosity=args.verbosity)

--- a/qgis_deployment_toolbelt/commands/upgrade.py
+++ b/qgis_deployment_toolbelt/commands/upgrade.py
@@ -30,7 +30,7 @@ from qgis_deployment_toolbelt.__about__ import (
     __title__,
     __title_clean__,
     __uri_repository__,
-    __version__ as actual_version,
+    __version_clean__ as actual_version,
 )
 from qgis_deployment_toolbelt.utils.bouncer import (
     exit_cli_error,


### PR DESCRIPTION
Since we're using setuptools_scm, version number is quite ugly in documentation. This PR adds logic to retrieve version from:

1. from GITHUB_REF (in context CI)
2. using local git command
3. fallback on package version

Local render:

<img width="1551" height="626" alt="image" src="https://github.com/user-attachments/assets/a1825c1e-4e77-41fd-aee2-54ceee5b777b" />
