### PR TITLE
improve(qgis-finder): use packaging to compare qgis versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "dulwich>=1.2.5,<2",
     "giturlparse>=0.12,<0.16",
     "imagesize>=2.0.0,<2.1",
-    "packaging>=22,<27",
+    "packaging>=26.3,<27",
     "pypac>=0.19,<1",
     "python-rule-engine>=0.5,<1.1",
     "python-win-ad==0.6.4 ; sys_platform == 'win32'",

--- a/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
+++ b/qgis_deployment_toolbelt/jobs/job_qgis_installation_finder.py
@@ -20,6 +20,9 @@ from pathlib import Path
 from shutil import which
 from sys import platform as opersys
 
+# 3rd party
+from packaging.version import InvalidVersion, Version
+
 # package
 from qgis_deployment_toolbelt.constants import (
     ENV_VAR_QGIS_EXE_PATH,
@@ -232,7 +235,7 @@ class JobQgisInstallationFinder(GenericJob):
 
     @staticmethod
     def _get_latest_version_from_list(versions: list[str]) -> str | None:
-        """Get latest version from a list, OSGEO4W are last.
+        """Get latest version from a list.
 
         Args:
             versions (list[str]): list of found version
@@ -240,12 +243,28 @@ class JobQgisInstallationFinder(GenericJob):
         Returns:
             str | None: latest version, None if no version provided
         """
-        if len(versions):
-            used_version = versions
-            used_version.sort(reverse=True)
-            return used_version[0]
+        if not versions:
+            return None
+        return max(versions, key=JobQgisInstallationFinder._version_sort_key)
 
-        return None
+    @staticmethod
+    def _version_sort_key(version_str: str) -> Version:
+        """Transforn a version string into a sortable and comparable Version object.
+
+        Args:
+            version_str (str): version string to parse, typically `X.Y.Z`.
+
+        Returns:
+            Version: parsed version, or `Version("0")` if parsing failed.
+        """
+        try:
+            return Version(version_str)
+        except InvalidVersion:
+            logger.warning(
+                f"Unparsable QGIS version, ignored for latest-version comparison: "
+                f"{version_str}"
+            )
+            return Version("0")
 
     @staticmethod
     def _get_latest_matching_version_path(

--- a/tests/test_job_qgis_installation_finder.py
+++ b/tests/test_job_qgis_installation_finder.py
@@ -5,10 +5,9 @@
 .. code-block:: python
 
     # for whole test
-    python -m unittest tests.job_qgis_installation_finder
+    python -m unittest tests.test_job_qgis_installation_finder
     # for specific
-    python -m unittest tests.job_qgis_installation_finder
-        .TestJobQgisInstallationFinder.test_get_latest_version_from_list
+    python -m unittest tests.job_qgis_installation_finder.TestJobQgisInstallationFinder.test_get_latest_version_from_list
 """
 
 # #############################################################################
@@ -43,9 +42,9 @@ class TestJobQgisInstallationFinder(unittest.TestCase):
         """Test definition of latest version from a list of version"""
         self.assertEqual(
             JobQgisInstallationFinder._get_latest_version_from_list(
-                ["3.25.1", "4.0.1", "3.28.2"]
+                ["3.25.1", "4.0.1", "4.1.0", "3.28.2"]
             ),
-            "4.0.1",
+            "4.1.0",
         )
 
     def test_get_latest_matching_version_path(self):
@@ -74,6 +73,68 @@ class TestJobQgisInstallationFinder(unittest.TestCase):
                 },
                 "3.36",
             )
+        )
+
+    def test_get_latest_version_from_list_empty(self):
+        """No versions given returns None."""
+        self.assertIsNone(JobQgisInstallationFinder._get_latest_version_from_list([]))
+
+    def test_get_latest_version_from_list_minor_multidigit(self):
+        """Regression: a single-digit minor must not outrank a double-digit one.
+
+        A plain lexicographic string sort ranks "3.8.0" above "3.44.0" because '8'
+        sorts after '4' at the same character position, ignoring that "44" is a
+        larger number than "8".
+        """
+        self.assertEqual(
+            JobQgisInstallationFinder._get_latest_version_from_list(
+                [
+                    "2",
+                    "3.8.0",
+                    "4.2.1",
+                    "3.44.0",
+                ]
+            ),
+            "4.2.1",
+        )
+
+    def test_get_latest_version_from_list_patch_multidigit(self):
+        """Regression: same bug at the patch level, e.g. late in an LTR branch's life."""
+        self.assertEqual(
+            JobQgisInstallationFinder._get_latest_version_from_list(
+                ["3.34.9", "3.34.10"]
+            ),
+            "3.34.10",
+        )
+
+    def test_get_latest_version_from_list_does_not_mutate_input(self):
+        """The input list is no longer sorted in place as a side effect."""
+        versions = ["3.34.10", "3.34.9", "3.28.1"]
+        original_order = list(versions)
+        JobQgisInstallationFinder._get_latest_version_from_list(versions)
+        self.assertEqual(versions, original_order)
+
+    def test_get_latest_version_from_list_unparsable_is_ignored(self):
+        """An unparsable version string is never selected, and doesn't raise."""
+        self.assertEqual(
+            JobQgisInstallationFinder._get_latest_version_from_list(
+                ["3.40.11", "not-a-version"]
+            ),
+            "3.40.11",
+        )
+
+    def test_get_latest_matching_version_path_patch_multidigit(self):
+        """Regression: version_priority selection was affected by the same bug."""
+        self.assertEqual(
+            JobQgisInstallationFinder._get_latest_matching_version_path(
+                {
+                    "3.34.1": "/path/to/3_34_1",
+                    "3.34.9": "/path/to/3_34_9",
+                    "3.34.10": "/path/to/3_34_10",
+                },
+                "3.34",
+            ),
+            "/path/to/3_34_10",
         )
 
     def test_get_installed_qgis_version_and_path_no_priority(self):


### PR DESCRIPTION
<!-- Thanks for your contribution to QGIS! Please make sure you read the following guidelines before opening a pull request. -->

## Description

Use [packaging](https://pypi.org/project/packaging) to parse and compare detected versions like in upgrade command, in plugins and profils versions comparison.

Funded by [la métropole du Grand Lyon](https://www.grandlyon.com/).

## Author's checklist

> If you're a regular contributor, you probably know this checklist by heart, so you can skip irrelevant items. But if it's your first contribution, please take the time to read it and check the items before opening the pull request.

- [x] I have read the [contributing guidelines](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md) and my pull request follows them.
- [x] My commits tend to comply with [Conventional Commits](https://www.conventionalcommits.org/); so they are descriptive and explain the rationale for changes. Messages and description are self-explanatory to make the git log a readable story of the project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] For commits which fix bugs include `Fixes #11111` at the bottom of the commit message.

> [!TIP]
> If you forgot to do this, don't be shy and write the same statement into this text field with the pull request description.

### AI tool usage

- [ ] AI tool(s) (Copilot, Claude, or something similar) supported my development of this PR. See our [policy about AI tool use](https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/main/CONTRIBUTING.md#ai-policy). Use of AI tools *must* be indicated. Failure to be honest might result in banning.
